### PR TITLE
WIP Use Lego.raw() before Array

### DIFF
--- a/test/query.js
+++ b/test/query.js
@@ -211,5 +211,19 @@ describe('query', function () {
 
 			assert.equal(query.text, 'UPDATE users SET age = $1, name = $2 WHERE id = $3');
 		});
+
+		it('array after regular parameter', () => {
+			const id = 1;
+			const params = {
+				age: 10,
+				name: 'Bob',
+			};
+      const keys = Object.keys(params);
+
+			const lego = Lego.sql `INSERT INTO users (${Lego.raw(keys.join(','))}) VALUES (${keys.map(key => Lego.sql `${params[key]}`)})`;
+			const query = lego.toQuery();
+
+			assert.equal(query.text, 'INSERT INTO users (age,name) VALUES ($1, $2)');
+		});
 	});
 });


### PR DESCRIPTION
That last fix you made worked really well, i've added a failing test for one other scenario I am using.

The actual in the test ends up being:

```
INSERT INTO users (age,name$1) VALUES ($2, )
```