### PR TITLE
Export base `Token` class for making custom tokens

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,3 +29,5 @@ export default {
 		return new RawToken(value);
 	},
 };
+
+export { default as Token } from './lego/tokens/token.js';


### PR DESCRIPTION
Making custom tokens is a great way to extend this lib to do all kinds of stuff, so exposing the Token class through the main export makes it easier to do so.